### PR TITLE
MNEMONIC-463: Should load native library in memory service lazily

### DIFF
--- a/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMemServiceImpl.java
@@ -30,12 +30,14 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PMemServiceImpl implements NonVolatileMemoryAllocatorService {
-  static {
+  private static boolean nativeLoaded = false;
+  static void loadNativeLibrary() {
     try {
       NativeLibraryLoader.loadFromJar("pmemallocator");
     } catch (Exception e) {
       throw new Error(e);
     }
+    nativeLoaded = true;
   }
 
   @Override
@@ -45,6 +47,9 @@ public class PMemServiceImpl implements NonVolatileMemoryAllocatorService {
 
   @Override
   public long init(long capacity, String uri, boolean isnew) {
+    if (!nativeLoaded) {
+      loadNativeLibrary();
+    }
     return ninit(capacity, uri, isnew);
   }
 

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/VMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/VMemServiceImpl.java
@@ -33,12 +33,14 @@ import java.util.Set;
 import java.util.HashSet;
 
 public class VMemServiceImpl implements VolatileMemoryAllocatorService {
-  static {
+  private static boolean nativeLoaded = false;
+  static void loadNativeLibrary() {
     try {
       NativeLibraryLoader.loadFromJar("vmemallocator");
     } catch (Exception e) {
       throw new Error(e);
     }
+    nativeLoaded = true;
   }
 
   protected Map<Long, Long> m_info = Collections.synchronizedMap(new HashMap<Long, Long>());
@@ -50,6 +52,9 @@ public class VMemServiceImpl implements VolatileMemoryAllocatorService {
 
   @Override
   public long init(long capacity, String uri, boolean isnew) {
+    if (!nativeLoaded) {
+      loadNativeLibrary();
+    }
     long ret = ninit(capacity, uri, isnew);
     m_info.put(ret, capacity);
     return ret;

--- a/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMallocServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/java/org/apache/mnemonic/service/memory/internal/PMallocServiceImpl.java
@@ -30,12 +30,14 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PMallocServiceImpl implements NonVolatileMemoryAllocatorService {
-  static {
+  private static boolean nativeLoaded = false;
+  static void loadNativeLibrary() {
     try {
       NativeLibraryLoader.loadFromJar("pmallocallocator");
     } catch (Exception e) {
       throw new Error(e);
     }
+    nativeLoaded = true;
   }
 
   @Override
@@ -45,6 +47,9 @@ public class PMallocServiceImpl implements NonVolatileMemoryAllocatorService {
 
   @Override
   public long init(long capacity, String uri, boolean isnew) {
+    if (!nativeLoaded) {
+      loadNativeLibrary();
+    }
     return ninit(capacity, uri, isnew);
   }
 
@@ -277,4 +282,5 @@ public class PMallocServiceImpl implements NonVolatileMemoryAllocatorService {
   public ResultSet query(long id, String querystr) {
     throw new UnsupportedOperationException();
   }
+
 }

--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/SysVMemServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/java/org/apache/mnemonic/service/memory/internal/SysVMemServiceImpl.java
@@ -33,12 +33,14 @@ import java.util.Set;
 import java.util.HashSet;
 
 public class SysVMemServiceImpl implements VolatileMemoryAllocatorService {
-  static {
+  private static boolean nativeLoaded = false;
+  static void loadNativeLibrary() {
     try {
       NativeLibraryLoader.loadFromJar("sysvmemallocator");
     } catch (Exception e) {
       throw new Error(e);
     }
+    nativeLoaded = true;
   }
 
   protected Map<Long, Long> m_info = Collections.synchronizedMap(new HashMap<Long, Long>());
@@ -50,6 +52,9 @@ public class SysVMemServiceImpl implements VolatileMemoryAllocatorService {
 
   @Override
   public long init(long capacity, String uri, boolean isnew) {
+    if (!nativeLoaded) {
+      loadNativeLibrary();
+    }
     long ret = ninit(capacity, uri, isnew);
     m_info.put(ret, capacity);
     return ret;


### PR DESCRIPTION
Now we have several memory allocator service implementations such as pmalloc, pmem, javavmem. Once we instantiate a memory allocator service, it would try to load native library for all implementations. As a result, we should prepare all of those native library even if we only use one kind of memory service. Loading native library should be lazy.