### PR TITLE
MNEMONIC-467: Simplify the example code of ShowOrder by using FactoryProxyHelper

### DIFF
--- a/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/ShowOrder.java
+++ b/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/ShowOrder.java
@@ -19,9 +19,8 @@ package org.apache.mnemonic.examples;
 
 import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
+import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.ParameterHolder;
-import org.apache.mnemonic.RestorableAllocator;
 import org.apache.mnemonic.Utils;
 
 public class ShowOrder {
@@ -34,32 +33,7 @@ public class ShowOrder {
 
     DurableType listgftypes[] = {DurableType.DURABLE};
 
-    EntityFactoryProxy listefproxies[] = {
-        new EntityFactoryProxy() {
-          @Override
-          public <A extends RestorableAllocator<A>> Product restore(
-              A allocator, EntityFactoryProxy[] factoryproxys,
-              DurableType[] gfields, long phandler, boolean autoreclaim) {
-            return ProductFactory.restore(allocator, factoryproxys, gfields, phandler, autoreclaim);
-          }
-          @Override
-          public <A extends RestorableAllocator<A>> Product restore(ParameterHolder<A> ph) {
-            return ProductFactory.restore(ph.getAllocator(),
-                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getHandler(), ph.getAutoReclaim());
-          }
-          @Override
-          public <A extends RestorableAllocator<A>> Product create(
-              A allocator, EntityFactoryProxy[] factoryproxys,
-              DurableType[] gfields, boolean autoreclaim) {
-            return ProductFactory.create(allocator, factoryproxys, gfields, autoreclaim);
-          }
-          @Override
-          public <A extends RestorableAllocator<A>> Product create(ParameterHolder<A> ph) {
-            return ProductFactory.create(ph.getAllocator(),
-                ph.getEntityFactoryProxies(), ph.getGenericTypes(), ph.getAutoReclaim());
-          }
-        }
-    };
+    EntityFactoryProxy listefproxies[] = {new EntityFactoryProxyHelper<Product>(Product.class) };
 
     long hdl = 0L;
     for (long keyid = 1; keyid <= 3; keyid++) {


### PR DESCRIPTION
This task is to simplify the example code of ShowOrder by using FactoryProxyHelper, similar to MNEMONIC-466