### PR TITLE
MNEMONIC-481: Add reference breaking operation in Durable class

### DIFF
--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableArrayImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableArrayImpl.java
@@ -167,6 +167,11 @@ public class DurableArrayImpl<A extends RestorableAllocator<A>, E>
   }
 
   @Override
+  public void refbreak() {
+    return;
+  }
+
+  @Override
   public void destroy() throws RetrieveDurableEntityError {
     long startAddr = holder.get();
     long endAddr = startAddr + MAX_OBJECT_SIZE * arraySize;

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashMapImpl.java
@@ -406,6 +406,11 @@ public class DurableHashMapImpl<A extends RestorableAllocator<A>, K, V>
   }
 
   @Override
+  public void refbreak() {
+    return;
+  }
+
+  @Override
   public void destroy() throws RetrieveDurableEntityError {
     long bucketAddr = holder.get();
     long maxbucketAddr = bucketAddr + MAX_OBJECT_SIZE * totalCapacity;

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashSetImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableHashSetImpl.java
@@ -125,6 +125,11 @@ public class DurableHashSetImpl<A extends RestorableAllocator<A>, E>
   }
 
   @Override
+  public void refbreak() {
+    return;
+  }
+
+  @Override
   public void destroy() throws RetrieveDurableEntityError {
     map.destroy();
   }

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableSinglyLinkedListImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableSinglyLinkedListImpl.java
@@ -123,6 +123,11 @@ public class DurableSinglyLinkedListImpl<A extends RestorableAllocator<A>, E>
   }
 
   @Override
+  public void refbreak() {
+    return;
+  }
+
+  @Override
   public void syncToVolatileMemory() {
     holder.syncToVolatileMemory();
   }

--- a/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableTreeImpl.java
+++ b/mnemonic-collections/src/main/java/org/apache/mnemonic/collections/DurableTreeImpl.java
@@ -523,6 +523,11 @@ public class DurableTreeImpl<A extends RestorableAllocator<A>, E extends Compara
   }
 
   @Override
+  public void refbreak() {
+    return;
+  }
+
+  @Override
   public void destroy() throws RetrieveDurableEntityError {
     destroy(root);
     holder.destroy();

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/AnnotatedDurableEntityClass.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/AnnotatedDurableEntityClass.java
@@ -194,6 +194,7 @@ public class AnnotatedDurableEntityClass {
     m_durablemtdinfo.put("syncToNonVolatileMemory", new ArrayList<MethodInfo>());
     m_durablemtdinfo.put("syncToLocal", new ArrayList<MethodInfo>());
     m_durablemtdinfo.put("getNativeFieldInfo", new ArrayList<MethodInfo>());
+    m_durablemtdinfo.put("refbreak", new ArrayList<MethodInfo>());
 
     m_entitymtdinfo.put("initializeDurableEntity", new MethodInfo());
     m_entitymtdinfo.put("createDurableEntity", new MethodInfo());
@@ -858,6 +859,9 @@ public class AnnotatedDurableEntityClass {
             break;
           case "getNativeFieldInfo":
             code.addStatement("return $1N", m_fieldsinfo.get("nfieldinfo").name);
+            break;
+          case "refbreak":
+            code.addStatement("return");
             break;
           default:
             throw new AnnotationProcessingException(null, "Method %s is not supported.", name);

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/Durable.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/Durable.java
@@ -117,4 +117,10 @@ public interface Durable {
    *
    */
   long[][] getNativeFieldInfo();
+
+  /**
+   * break all marked live references
+   */
+  void refbreak();
+
 }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/DurableBuffer.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/DurableBuffer.java
@@ -86,4 +86,9 @@ public class DurableBuffer<A extends RetrievableAllocator<A>> extends MemBufferH
     return null;
   }
 
+  @Override
+  public void refbreak() {
+    return;
+  }
+
 }

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/DurableChunk.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/DurableChunk.java
@@ -84,6 +84,11 @@ public class DurableChunk<A extends RetrievableAllocator<A>> extends MemChunkHol
     return null;
   }
 
+  @Override
+  public void refbreak() {
+    return;
+  }
+
   /**
    * Get a buffer backed by a region of DurableChunk
    * @param offset

--- a/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
@@ -571,4 +571,9 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
   public long[][] getNativeFieldInfo() {
     throw new UnsupportedOperationException("getNativeFieldInfo() on Generic Field.");
   }
+
+  @Override
+  public void refbreak() {
+    return;
+  }
 }


### PR DESCRIPTION
The reference breaking operation should be exposed by durable class for the developer to use. this function would break the reference of linked objects and release them if no more strong reference to them.