### PR TITLE
MNEMONIC-458: Upgrade Spark artifacts to v2.3.0

### DIFF
--- a/mnemonic-spark/pom.xml
+++ b/mnemonic-spark/pom.xml
@@ -35,7 +35,7 @@
   <url>http://mnemonic.apache.org</url>
 
   <properties>
-    <spark.version>2.1.1</spark.version>
+    <spark.version>2.3.0</spark.version>
     <scala.version>2.11.8</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scalatest.version>3.0.1</scalatest.version>


### PR DESCRIPTION
Reviewers ask to upgrade Spark dependencies from the old version to latest one. 

Previous task description requires to upgrade spark version to 2.2.1. Now the latest spark version is 2.3.0. The task description has been updated to reflect this change, and the upgrade has been verified with all test cases passed.