### PR TITLE
MNEMONIC-493: Implement the functionality of reference breaking mark for generic field

### DIFF
--- a/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/GenericField.java
@@ -574,6 +574,9 @@ public class GenericField<A extends RestorableAllocator<A>, E> implements Durabl
 
   @Override
   public void refbreak() {
-    return;
+    m_field = null;
+    m_strfield = null;
+    m_chunkfield = null;
+    m_bufferfield = null;
   }
 }


### PR DESCRIPTION
The generic field should implement the refbreak() operation from the durable interface for releasing underlying resource from its heap.