### PR TITLE
Fix SuppressionFilter initialization failure

### DIFF
--- a/bin/mnemonic-checkstyle.xml
+++ b/bin/mnemonic-checkstyle.xml
@@ -164,7 +164,4 @@
 
     <module name="SuppressionCommentFilter"/>
 
-    <module name="SuppressionFilter">
-      <property name="file" value="bin/suppressions.xml"/>
-    </module>
 </module>

--- a/mnemonic-core/pom.xml
+++ b/mnemonic-core/pom.xml
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.squareup</groupId>
       <artifactId>javapoet</artifactId>
-    </dependency>    
+    </dependency>
     <!-- logging dependencies -->
     <!-- For core, assume all APIs will be used -->
     <dependency>
@@ -184,7 +184,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId> 
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>-Xmx2g -XX:MaxPermSize=1g</argLine>
@@ -192,11 +192,10 @@
                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
               </suiteXmlFiles>
             </configuration>
-          </plugin> 
+          </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
 
 </project>
-

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/pom.xml
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>mnemonic-memory-services</artifactId>
     <version>0.12.0-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>mnemonic-nvml-vmem-service</artifactId>
   <name>mnemonic-nvml-vmem-service</name>
 
@@ -150,7 +150,7 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.apache.maven.plugins</groupId> 
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <argLine>-Xmx2g -XX:MaxPermSize=1g</argLine>
@@ -158,7 +158,7 @@
                 <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
               </suiteXmlFiles>
             </configuration>
-          </plugin> 
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -290,9 +290,11 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>3.0.0</version>
           <configuration>
             <configLocation>bin/mnemonic-checkstyle.xml</configLocation>
+            <suppressionsLocation>bin/suppressions.xml</suppressionsLocation>
+            <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
             <encoding>UTF-8</encoding>
             <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
The project building shows the following issue.

> ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:2.17:check (validate) on project mnemonic-nvml-vmem-service: Failed during checkstyle configuration: cannot initialize module SuppressionFilter - Cannot set property 'file' to 'bin/suppressions.xml' in module SuppressionFilter: InvocationTargetException: Unable to find: bin/suppressions.xml -> [Help 1]

This PR fixes up that building error and upgrades the maven checkstyle plugin.

Fixes #122