### PR TITLE
Fix undefined reference to pthread_create for native library building

### DIFF
--- a/mnemonic-computing-services/mnemonic-utilities-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/main/native/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(utilitiescomputing SHARED common.c
   org_apache_mnemonic_service_computing_internal_PrintServiceImpl.c
   org_apache_mnemonic_service_computing_internal_VectorizationServiceImpl.c)
 target_include_directories(utilitiescomputing PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(utilitiescomputing ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/native/CMakeLists.txt
@@ -50,7 +50,7 @@ endif (NOT LIBPMEMOBJ_LIBRARIES)
 
 add_library(pmemallocator SHARED common.c org_apache_mnemonic_service_memory_internal_PMemServiceImpl.c)
 target_include_directories(pmemallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(pmemallocator ${LIBPMEMOBJ_LIBRARIES} ${LIBPMEM_LIBRARIES})
+target_link_libraries(pmemallocator ${LIBPMEMOBJ_LIBRARIES} ${LIBPMEM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/CMakeLists.txt
@@ -45,7 +45,7 @@ endif (NOT LIBVMEM_LIBRARIES)
 
 add_library(vmemallocator SHARED common.c org_apache_mnemonic_service_memory_internal_VMemServiceImpl.c)
 target_include_directories(vmemallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(vmemallocator ${LIBVMEM_LIBRARIES})
+target_link_libraries(vmemallocator ${LIBVMEM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
@@ -47,7 +47,7 @@ endif (NOT LIBPMALLOC_LIBRARIES)
 
 add_library(pmallocallocator SHARED common.c org_apache_mnemonic_service_memory_internal_PMallocServiceImpl.c)
 target_include_directories(pmallocallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(pmallocallocator ${LIBPMALLOC_LIBRARIES})
+target_link_libraries(pmallocallocator ${LIBPMALLOC_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-pmdk-pmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmdk-pmem-service/src/main/native/CMakeLists.txt
@@ -50,7 +50,7 @@ endif (NOT LIBPMEMOBJ_LIBRARIES)
 
 add_library(pmdkpmemallocator SHARED common.c org_apache_mnemonic_service_memory_internal_PMDKPMemServiceImpl.c)
 target_include_directories(pmdkpmemallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(pmdkpmemallocator ${LIBPMEMOBJ_LIBRARIES} ${LIBPMEM_LIBRARIES})
+target_link_libraries(pmdkpmemallocator ${LIBPMEMOBJ_LIBRARIES} ${LIBPMEM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-pmdk-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmdk-vmem-service/src/main/native/CMakeLists.txt
@@ -45,7 +45,7 @@ endif (NOT LIBVMEM_LIBRARIES)
 
 add_library(pmdkvmemallocator SHARED common.c org_apache_mnemonic_service_memory_internal_PMDKVMemServiceImpl.c)
 target_include_directories(pmdkvmemallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(pmdkvmemallocator ${LIBVMEM_LIBRARIES})
+target_link_libraries(pmdkvmemallocator ${LIBVMEM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/native/CMakeLists.txt
@@ -40,6 +40,7 @@ include_directories(${CMAKE_THREAD_LIBS_INIT})
 
 add_library(sysvmemallocator SHARED common.c org_apache_mnemonic_service_memory_internal_SysVMemServiceImpl.c)
 target_include_directories(sysvmemallocator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(sysvmemallocator ${CMAKE_THREAD_LIBS_INIT})
 
 include (InstallRequiredSystemLibraries)
 set (CPACK_RESOURCE_FILE_LICENSE

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
-          <version>1.8</version>
+          <version>3.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR fixes the undefined pthread_create issue and upgrade the version of maven antrun plugin

Fixes #123