### PR TITLE
Adopt pmem packages in CentOS docker file

### DIFF
--- a/docker/docker-CentOS/Dockerfile
+++ b/docker/docker-CentOS/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM centos:7.4.1708
+FROM centos:8
 MAINTAINER Gang Wang (garyw@apache.org)
 
 #set up your proxy below, please refer to readme in the Docker folder
@@ -28,15 +28,11 @@ ENV HTTPS_PROXY ${http_proxy}
 
 RUN echo The proxy set : ${http_proxy}
 
-RUN curl -sSL https://s3.amazonaws.com/download.fpcomplete.com/centos/7/fpco.repo | tee /etc/yum.repos.d/fpco.repo
-
 RUN yum -y install epel-release
 RUN yum -y update && yum -y groupinstall 'Development Tools' && \
-    yum -y install java-devel cmake check check-devel libuuid-devel man zlib-devel wget stack && yum clean all
+    yum -y install java-devel cmake check check-devel libuuid-devel man zlib-devel && yum clean all
 
-# required packages by pmdk
-RUN yum install -y which autoconf asciidoc xmlto automake libtool kmod-devel libudev-devel uuid-devel json-c-devel \
-                   asciidoc asciidoc-doc bash-completion graphviz keyutils-libs-devel asciidoctor ndctl ndctl-devel daxctl daxctl-devel
+RUN mkdir -p /ws
 
 RUN curl -O http://mirror.cogentco.com/pub/apache/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz && \
     tar xvf apache-maven-3.5.4-bin.tar.gz && \
@@ -48,33 +44,10 @@ ENV PATH $M2:$PATH
 ENV JAVA_HOME /usr/lib/jvm/java
 ENV PATH $JAVA_HOME/bin:$PATH
 
-RUN mkdir -p /ws && cd /ws && wget https://hackage.haskell.org/package/pandoc-1.17.0.3/pandoc-1.17.0.3.tar.gz && \
-    tar xvzf pandoc-1.17.0.3.tar.gz && \
-    mv pandoc-1.17.0.3 pandoc && \
-    rm pandoc-1.17.0.3.tar.gz
-
-RUN cd /ws/pandoc && stack setup && stack install
-ENV PD_HOME /ws/pandoc/.stack-work/install/x86_64-linux/lts-5.8/7.10.3/bin
-ENV PATH $PD_HOME:$PATH
-
 RUN cd /ws && git clone https://github.com/NonVolatileComputing/pmalloc.git && \
     cd pmalloc && mkdir build && cd build && cmake .. && make && make install
 
-RUN cd /ws && git clone https://github.com/pmem/nvml.git && \
-    cd nvml && git checkout 630862e82f && make && make install
-
-# deploy ndctl required by pmdk
-#RUN cd /ws && git clone https://github.com/pmem/ndctl.git && \
-#    cd ndctl && git checkout ndctl-64.y && \
-#    ./autogen.sh && ./configure CFLAGS='-g -O0' --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib && \
-#    make && make check && make install
-
-# deploy pmdk
-RUN cd /ws && git clone https://github.com/pmem/pmdk.git && \
-    cd pmdk && git checkout stable-1.6 && make && \
-#    the test run time is too long
-#    cp src/test/testconfig.sh.example src/test/testconfig.sh && make check && \
-    make install
+RUN yum -y install ndctl-devel libpmem-devel libvmem-devel libpmemobj-devel
 
 RUN touch /etc/profile.d/mvn.sh && chmod +x /etc/profile.d/mvn.sh && \
     if [ "x" != "x${proxy_host}" ]; then echo export MAVEN_OPTS="\" -DproxySet=\\\"true\\\" -DproxyHost=${proxy_host} -DproxyPort=${proxy_port} \"" > /etc/profile.d/mvn.sh; fi


### PR DESCRIPTION
This PR updates the Docker file to install pmem packages from CentOS repos instead of building from its source.

Fixes #130 