### PR TITLE
Refactor the deployment of Maven in Ubuntu Dockerfile

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,33 +1,21 @@
 <img src="https://mnemonic.apache.org/img/mnemonic_logo.png" width=200 />
 
-================================ 
+================================
 
-This is the "Dockerfile" that will automatically build the CentOS/Ubuntu environment of this project. 
+This is the "Dockerfile" that will automatically build the CentOS/Ubuntu environment of this project.
 
 --------------
 ### Features:
 
-*What does the Dockerfile do?* 
+*What does the Dockerfile do?*
 
 - 1. Build from centos/ubuntu.
-- 2. Default is not using proxy. Please see instruction below to set up http/https proxy.
-- 3. Install dependency packages.
-- 4. Set up environment variables of paths.
-- 5. Create /ws folder.
-- 6. Install pmalloc in /ws
-- 7. Install nvml in /ws.
-- 8. Set up maven proxy mvn.sh.
-- 9. Clone mnemonic code then build/install.  
-- 10. Go to /ws fold and start bash.  
-
-#### How to set up proxy? 
-
-Set the argument "http_proxy" for the docker option "--build-arg" as follows
-```bash
-  $ docker build -t NAME[:TAG] --build-arg proxy_host="<proxy_host>" proxy_port="<proxy_port>" .
-```
-
-For old version docker v1.10 below, Please replace ARG with ENV and set its value as proxy strings in Dockerfile instead
+- 2. Install dependency packages.
+- 3. Set up environment variables of paths.
+- 4. Create /ws folder.
+- 5. Install pmalloc in /ws
+- 6. Clone mnemonic code then build/install.
+- 7. Go to /ws fold and start bash.
 
 ### How to build the docker image from Dockerfile in host OS?
 Build from git repository
@@ -39,7 +27,7 @@ Build from git repository
 
 -- OR --
 
-In the folder of Dockerfile, run: 
+In the folder of Dockerfile, run:
 
 ```bash
   $ docker build -t NAME[:TAG] .
@@ -47,10 +35,10 @@ In the folder of Dockerfile, run:
 
 * More detials please refer to [Docker build reference](https://docs.docker.com/engine/reference/commandline/build/)
 
-#### Optional: After build, push image to dockerhub: 
+#### Optional: After build, push image to dockerhub:
 
 ```bash
-  $ docker login [OPTIONS] [SERVER]  
+  $ docker login [OPTIONS] [SERVER]
   $ docker push [OPTIONS] NAME[:TAG]
 ```
 
@@ -73,4 +61,3 @@ Run image:
 Note: this command will override the container's project folder, you can use another name to avoid it.
 
  * More details please refer to [Docker run reference](https://docs.docker.com/engine/reference/run/)
-

--- a/docker/docker-Ubuntu/Dockerfile
+++ b/docker/docker-Ubuntu/Dockerfile
@@ -18,50 +18,26 @@
 FROM ubuntu:18.04
 MAINTAINER Yanhui Zhao (yanhui.zhao@outlook.com)
 
-#set up your proxy below, please refer to readme in the Docker folder
-ARG proxy_host=""
-ARG proxy_port=""
-ENV http_proxy ${proxy_host:+"http://${proxy_host}:${proxy_port}"}
-ENV https_proxy ${http_proxy}
-ENV HTTP_PROXY ${http_proxy}
-ENV HTTPS_PROXY ${http_proxy}
-
-RUN echo The proxy set : ${http_proxy}
-
 RUN apt-get -y update && \
-    apt-get install -y default-jdk cmake check git pkg-config autoconf man build-essential gcc g++ uuid-dev pandoc devscripts flex doxygen
-
-RUN apt-get clean
-
-RUN curl -O http://mirror.cogentco.com/pub/apache/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz && \
-    tar xvf apache-maven-3.5.4-bin.tar.gz && \
-    mv apache-maven-3.5.4 /usr/local/apache-maven
-
-ENV M2_HOME /usr/local/apache-maven
-ENV M2 $M2_HOME/bin
-ENV PATH $M2:$PATH
-ENV JAVA_HOME /usr/lib/jvm/default-java
-ENV PATH $JAVA_HOME/bin:$PATH
-
-RUN mkdir -p /ws
-RUN cd /ws && git clone https://github.com/NonVolatileComputing/pmalloc.git && \
-    cd pmalloc && mkdir build && cd build && cmake .. && make && make install
+    apt-get install -y default-jdk cmake check git pkg-config autoconf man build-essential gcc g++ uuid-dev pandoc devscripts flex doxygen maven
 
 RUN apt-get install -y libndctl-dev libpmem-dev libvmem-dev libpmemobj-dev
 
-RUN touch /etc/profile.d/mvn.sh && chmod +x /etc/profile.d/mvn.sh && \
-    if [ "x" != "x${proxy_host}" ]; then echo export MAVEN_OPTS="\" -DproxySet=\\\"true\\\" -DproxyHost=${proxy_host} -DproxyPort=${proxy_port} \"" > /etc/profile.d/mvn.sh; fi
+RUN apt-get clean
 
-RUN cat /etc/profile.d/mvn.sh > ~/.bash_profile
-RUN cat /etc/profile.d/mvn.sh > ~/.bashrc
+ENV JAVA_HOME /usr/lib/jvm/default-java
+ENV PATH $JAVA_HOME/bin:$PATH
 
-RUN . /etc/profile.d/mvn.sh && cd /ws && git clone https://github.com/apache/mnemonic.git && \
+WORKDIR /ws
+
+RUN git clone https://github.com/NonVolatileComputing/pmalloc.git && \
+    cd pmalloc && mkdir build && cd build && cmake .. && make && make install
+
+RUN git clone https://github.com/apache/mnemonic.git && \
     cd mnemonic && mvn clean package install
 
 ENV MNEMONIC_HOME /ws/mnemonic
 
 #RUN cd /ws/mnemonic && bin/runall.sh -y
-
-WORKDIR /ws
 
 CMD ["bash"]


### PR DESCRIPTION
This patch replaces the manually installation of Maven with apt install maven,
becaues the version of Maven of Ubuntu 18 is greater than v3.5.4.
The proxy settings for Maven also been removed to simplify the configuration.
The README file has been updated to reflect the changes to Dockerfiles.

Fixes #134