### PR TITLE
MNEMONIC-542: Configure the dependencyManagement artifacts of whole project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,18 @@ subprojects {
   dependencyManagement {
     dependencies {
       dependency 'org.apache.commons:commons-lang3:3.4'
+      dependency 'org.testng:testng:6.8.17'
+      dependency 'org.flowcomputing.commons:commons-resgc:0.8.17.1'
+      dependency 'org.flowcomputing.commons:commons-primitives:0.6.1'
+      dependency 'commons-cli:commons-cli:1.3.1'
+      dependency 'com.squareup:javapoet:1.11.1'
+      dependency 'org.slf4j:slf4j-api:1.7.21'
+      dependency 'org.slf4j:slf4j-log4j12:1.7.21'
+      dependency 'org.slf4j:jul-to-slf4j:1.7.21'
+      dependency 'org.slf4j:jcl-over-slf4j:1.7.21'
+      dependency 'log4j:log4j:1.2.17'
+      dependency 'ch.qos.logback:logback-classic:1.1.7'
+      dependency 'ch.qos.logback:logback-core:1.1.7'
     }
   }
 


### PR DESCRIPTION
This patch added all dependent artifacts to Gradle build script according to the section of dependencyManagement. 
I cannot verify the completeness for Gradle building for now, I think missing artifacts could be added later on demand.