### PR TITLE
MNEMONIC-546: Create build.gradle for subproject mnemonic-common

### DIFF
--- a/mnemonic-common/build.gradle
+++ b/mnemonic-common/build.gradle
@@ -17,12 +17,12 @@
 
 description = 'mnemonic-common'
 dependencies {
-    compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.4'
-    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jul-to-slf4j', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jcl-over-slf4j', version:'1.7.21'
-    compile group: 'log4j', name: 'log4j', version:'1.2.17'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.21'
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    implementation 'org.apache.commons:commons-lang3'
+    implementation 'org.slf4j:slf4j-api'
+    implementation 'org.slf4j:jul-to-slf4j'
+    implementation 'org.slf4j:jcl-over-slf4j'
+    implementation 'log4j:log4j'
+    implementation 'org.slf4j:slf4j-log4j12'
+    testImplementation 'org.testng:testng'
 }
 test.useTestNG()


### PR DESCRIPTION
This patch makes it compatible with Gradle 7 as well.