### PR TITLE
MNEMONIC-552 Enable annotation processing for the test cases of mnemonic-core

### DIFF
--- a/mnemonic-core/build.gradle
+++ b/mnemonic-core/build.gradle
@@ -16,16 +16,25 @@
  */
 
 description = 'mnemonic-core'
+
+compileTestJava {
+    options.compilerArgs = [
+       "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+    ]
+}
+
 dependencies {
-    compileOnly 'org.apache.commons:commons-lang3'
-    compileOnly 'org.flowcomputing.commons:commons-resgc'
-    compileOnly 'org.flowcomputing.commons:commons-primitives'
-    compileOnly 'com.squareup:javapoet'
-    compileOnly 'org.slf4j:slf4j-api'
-    compileOnly 'org.slf4j:jul-to-slf4j'
-    compileOnly 'org.slf4j:jcl-over-slf4j'
-    compileOnly 'log4j:log4j'
-    compileOnly 'org.slf4j:slf4j-log4j12'
+    api 'org.apache.commons:commons-lang3'
+    api 'org.flowcomputing.commons:commons-resgc'
+    api 'org.flowcomputing.commons:commons-primitives'
+    api 'com.squareup:javapoet'
+    api 'org.slf4j:slf4j-api'
+    api 'org.slf4j:jul-to-slf4j'
+    api 'org.slf4j:jcl-over-slf4j'
+    api 'log4j:log4j'
+    api 'org.slf4j:slf4j-log4j12'
+    testAnnotationProcessor project(':mnemonic-core')
+    testCompileOnly project(':mnemonic-core')
     testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()


### PR DESCRIPTION
The test cases of mnemonic-core needs to get annotation processing from the its own sub-project. there is a testAnnotationProcessor instruction that has been supported by Gradle to handle it.