### PR TITLE
MNEMONIC-548: Fix deprecated warning in gradle 7

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mnemonic-computing-services/mnemonic-utilities-service/build.gradle
+++ b/mnemonic-computing-services/mnemonic-utilities-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-utilities-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-examples/build.gradle
+++ b/mnemonic-examples/build.gradle
@@ -17,11 +17,11 @@
 
 description = 'mnemonic-examples'
 dependencies {
-  compile project(':mnemonic-core')
-  compile project(':mnemonic-collections')
-    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jul-to-slf4j', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jcl-over-slf4j', version:'1.7.21'
-    compile group: 'log4j', name: 'log4j', version:'1.2.17'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.21'
+  compileOnly project(':mnemonic-core')
+  compileOnly project(':mnemonic-collections')
+  compileOnly 'org.slf4j:slf4j-api'
+  compileOnly 'org.slf4j:jul-to-slf4j'
+  compileOnly 'org.slf4j:jcl-over-slf4j'
+  compileOnly 'log4j:log4j'
+  compileOnly 'org.slf4j:slf4j-log4j12'
 }

--- a/mnemonic-memory-services/mnemonic-java-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-java-vmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-java-vmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-nvml-pmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-nvml-pmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-nvml-pmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-nvml-vmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-pmalloc-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-pmalloc-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-pmdk-pmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-pmdk-pmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-pmdk-pmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-pmdk-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-pmdk-vmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-pmdk-vmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/build.gradle
@@ -17,6 +17,6 @@
 
 description = 'mnemonic-sys-vmem-service'
 dependencies {
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+    testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()

--- a/mnemonic-query/build.gradle
+++ b/mnemonic-query/build.gradle
@@ -17,14 +17,14 @@
 
 description = 'mnemonic-query'
 dependencies {
-  compile project(':mnemonic-core')
-  compile project(':mnemonic-collections')
-    compile group: 'org.apache.commons', name: 'commons-lang3', version:'3.4'
-    compile group: 'org.slf4j', name: 'slf4j-api', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jul-to-slf4j', version:'1.7.21'
-    compile group: 'org.slf4j', name: 'jcl-over-slf4j', version:'1.7.21'
-    compile group: 'log4j', name: 'log4j', version:'1.2.17'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.21'
-    testCompile group: 'org.testng', name: 'testng', version:'6.8.17'
+  compileOnly project(':mnemonic-core')
+  compileOnly project(':mnemonic-collections')
+  compileOnly 'org.apache.commons:commons-lang3'
+  compileOnly 'org.slf4j:slf4j-api'
+  compileOnly 'org.slf4j:jul-to-slf4j'
+  compileOnly 'org.slf4j:jcl-over-slf4j'
+  compileOnly 'log4j:log4j'
+  compileOnly 'org.slf4j:slf4j-log4j12'
+  testCompileOnly 'org.testng:testng'
 }
 test.useTestNG()


### PR DESCRIPTION
Fix "dependency" has been deprecated warning in Gradle 7 and upgraded to latest Gradle.