### PR TITLE
MNEMONIC-551:Switch insecure protocols to secure ones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ subprojects {
   }
 
   repositories {
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
     mavenCentral()
   }
 


### PR DESCRIPTION
The Gradle build shows the following warnings that needs to be addressed

Using insecure protocols with repositories has been deprecated. This is scheduled to be removed in Gradle 7.0. Switch Maven repository 'maven(http://repo.maven.apache.org/maven2)' to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/6.6.1/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details.