### PR TITLE
MNMONIC-560: Fix unexpected '}' in build.gradle of mnemonic-sys-vmem-service

### DIFF
--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/build.gradle
@@ -59,6 +59,4 @@ processResources.dependsOn copyResources
 build.dependsOn shadowJar
 clean.dependsOn cmakeClean
 clean.dependsOn cleanDist
-
-}
 test.useTestNG()


### PR DESCRIPTION
Bug fix