### PR TITLE
MNEMONIC-540: Enable annotation processing for mnemonic-collections

### DIFF
--- a/mnemonic-collections/build.gradle
+++ b/mnemonic-collections/build.gradle
@@ -17,15 +17,30 @@
 
 
 description = 'mnemonic-collections'
+
+compileJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
+}
+
+compileTestJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
+}
+
 dependencies {
-  compileOnly project(':mnemonic-core')
-  compileOnly 'org.apache.commons:commons-lang3'
-  compileOnly 'org.flowcomputing.commons:commons-primitives'
-  compileOnly 'org.slf4j:slf4j-api'
-  compileOnly 'org.slf4j:jul-to-slf4j'
-  compileOnly 'org.slf4j:jcl-over-slf4j'
-  compileOnly 'log4j:log4j'
-  compileOnly 'org.slf4j:slf4j-log4j12'
+  annotationProcessor project(':mnemonic-core')
+  api project(':mnemonic-core')
+  api 'org.apache.commons:commons-lang3'
+  api 'org.flowcomputing.commons:commons-primitives'
+  api 'org.slf4j:slf4j-api'
+  api 'org.slf4j:jul-to-slf4j'
+  api 'org.slf4j:jcl-over-slf4j'
+  api 'log4j:log4j'
+  api 'org.slf4j:slf4j-log4j12'
   testCompileOnly 'org.testng:testng'
 }
+
 test.useTestNG()


### PR DESCRIPTION
It is similar to enable annotation processing for the test cases of mnemonic-core. but this ticket asks for applying it on durable collections under this subproject.