### PR TITLE
MNEMONIC-562: Complete the build of mnemonic-nvml-vmem-service

### DIFF
--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/build.gradle
@@ -15,8 +15,48 @@
  * limitations under the License.
  */
 
-description = 'mnemonic-nvml-vmem-service'
-dependencies {
-    testCompileOnly 'org.testng:testng'
+plugins {
+  id 'net.freudasoft.gradle-cmake-plugin'
+  id 'com.github.johnrengelman.shadow'
+  id 'com.google.osdetector'
 }
+
+description = 'mnemonic-nvml-vmem-service'
+
+dependencies {
+  implementation project(':mnemonic-core')
+  implementation 'org.flowcomputing.commons:commons-primitives'
+  testCompileOnly 'org.testng:testng'
+}
+
+def nativeDir = "$projectDir/src/main/native"
+
+cmake {
+  sourceFolder = file("$nativeDir")
+  workingFolder = file("$nativeDir/build")
+  buildSharedLibs = true
+  buildConfig = 'Release'
+  buildTarget = 'install'
+}
+
+task copyResources(type: Copy) {
+  from "$nativeDir/dist/native"
+  into "${buildDir}/classes/java/main/native"
+}
+
+shadowJar {
+  minimize()
+  destinationDirectory = file("$projectDir/../service-dist")
+  archiveClassifier = osdetector.classifier
+}
+
+task cleanDist(type: Delete) {
+  delete "$nativeDir/dist"
+}
+
+compileJava.dependsOn cmakeBuild
+processResources.dependsOn copyResources
+build.dependsOn shadowJar
+clean.dependsOn cmakeClean
+clean.dependsOn cleanDist
 test.useTestNG()


### PR DESCRIPTION
This memory service relies on a native code to work, it does rely on external persistent memory libraries to work. it is a challenge task to deploy the external library and build it.

Local build passed
 ./gradlew :mnemonic-memory-service:mnemonic-nvml-vmem-service:clean -x test
BUILD SUCCESSFUL in 648ms
3 actionable tasks: 3 executed
./gradlew :mnemonic-memory-service:mnemonic-nvml-vmem-service:build -x test
BUILD SUCCESSFUL in 1s
10 actionable tasks: 6 executed, 4 up-to-date
