### PR TITLE
MNEMONIC-561

### DIFF
--- a/mnemonic-memory-services/mnemonic-pmalloc-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/build.gradle
@@ -15,8 +15,49 @@
  * limitations under the License.
  */
 
-description = 'mnemonic-pmalloc-service'
-dependencies {
-    testCompileOnly 'org.testng:testng'
+plugins {
+  id 'net.freudasoft.gradle-cmake-plugin'
+  id 'com.github.johnrengelman.shadow'
+  id 'com.google.osdetector'
 }
+
+description = 'mnemonic-pmalloc-service'
+
+dependencies {
+  implementation project(':mnemonic-core')
+  implementation 'org.flowcomputing.commons:commons-primitives'
+  testCompileOnly 'org.testng:testng'
+}
+
+def nativeDir = "$projectDir/src/main/native"
+
+cmake {
+  sourceFolder = file("$nativeDir")
+  workingFolder = file("$nativeDir/build")
+  buildSharedLibs = true
+  buildConfig = 'Release'
+  buildTarget = 'install'
+}
+
+task copyResources(type: Copy) {
+  from "$nativeDir/dist/native"
+  into "${buildDir}/classes/java/main/native"
+}
+
+shadowJar {
+  minimize()
+  destinationDirectory = file("$projectDir/../service-dist")
+  archiveClassifier = osdetector.classifier
+}
+
+task cleanDist(type: Delete) {
+  delete "$nativeDir/dist"
+}
+
+compileJava.dependsOn cmakeBuild
+processResources.dependsOn copyResources
+build.dependsOn shadowJar
+clean.dependsOn cmakeClean
+clean.dependsOn cleanDist
+
 test.useTestNG()


### PR DESCRIPTION
Signed-off-by: chenyang <chenyang@apache.org>
Address the 561 issue"This memory service relies on a native code to work, it does rely on external special 3rd part libraries to work"