### PR TITLE
MNEMONIC-574: Add missing sub projects to settings.gradle

### DIFF
--- a/mnemonic-benches/mnemonic-sort-bench/build.gradle
+++ b/mnemonic-benches/mnemonic-sort-bench/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = 'mnemonic-sort-bench'
+dependencies {
+    testCompileOnly 'org.testng:testng'
+}
+test.useTestNG()

--- a/mnemonic-benches/mnemonic-spark-kmeans-bench/build.gradle
+++ b/mnemonic-benches/mnemonic-spark-kmeans-bench/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = 'mnemonic-spark-kmeans-bench'
+dependencies {
+    testCompileOnly 'org.testng:testng'
+}
+test.useTestNG()

--- a/mnemonic-hadoop/mnemonic-hadoop-mapreduce/build.gradle
+++ b/mnemonic-hadoop/mnemonic-hadoop-mapreduce/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = 'mnemonic-hadoop-mapreduce'
+dependencies {
+    testCompileOnly 'org.testng:testng'
+}
+test.useTestNG()

--- a/mnemonic-sessions/build.gradle
+++ b/mnemonic-sessions/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = 'mnemonic-sessions'
+dependencies {
+    testCompileOnly 'org.testng:testng'
+}
+test.useTestNG()

--- a/mnemonic-spark/mnemonic-spark-core/build.gradle
+++ b/mnemonic-spark/mnemonic-spark-core/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+description = 'mnemonic-spark-core'
+dependencies {
+    testCompileOnly 'org.testng:testng'
+}
+test.useTestNG()

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,11 @@ include ':mnemonic-computing-services:mnemonic-utilities-service'
 include ':mnemonic-computing-services'
 include ':mnemonic-query'
 include ':mnemonic-common'
+include ':mnemonic-benches:mnemonic-sort-bench'
+include ':mnemonic-benches:mnemonic-spark-kmeans-bench'
+include ':mnemonic-sessions'
+include ':mnemonic-spark:mnemonic-spark-core'
+include ':mnemonic-hadoop:mnemonic-hadoop-mapreduce'
 
 project(':mnemonic-core').projectDir = "$rootDir/mnemonic-core" as File
 project(':mnemonic-collections').projectDir = "$rootDir/mnemonic-collections" as File
@@ -47,3 +52,8 @@ project(':mnemonic-computing-services:mnemonic-utilities-service').projectDir = 
 project(':mnemonic-computing-services').projectDir = "$rootDir/mnemonic-computing-services" as File
 project(':mnemonic-query').projectDir = "$rootDir/mnemonic-query" as File
 project(':mnemonic-common').projectDir = "$rootDir/mnemonic-common" as File
+project(':mnemonic-benches:mnemonic-sort-bench').projectDir = "mnemonic-benches/mnemonic-sort-bench" as File
+project(':mnemonic-benches:mnemonic-spark-kmeans-bench').projectDir = "$rootDir/mnemonic-benches/mnemonic-spark-kmeans-bench" as File
+project(':mnemonic-sessions').projectDir = "$rootDir/mnemonic-sessions" as File
+project(':mnemonic-spark:mnemonic-spark-core').projectDir = "$rootDir/mnemonic-spark/mnemonic-spark-core" as File
+project(':mnemonic-hadoop:mnemonic-hadoop-mapreduce').projectDir = "$rootDir/mnemonic-hadoop/mnemonic-hadoop-mapreduce" as File


### PR DESCRIPTION
There are several sub projects missing in settings.gradle, i.e. mnemonic-benches, mnemonic-sessions, mnemonic-spark, mnemonic-hadoop. those need to be added to Gradle settings file for building.

Signed-off-by: Yanhui Zhao <yzhao@apache.org>