### PR TITLE
MNEMONIC-568 Create build.gradle for subproject mnemonic-examples

### DIFF
--- a/mnemonic-examples/build.gradle
+++ b/mnemonic-examples/build.gradle
@@ -15,13 +15,32 @@
  * limitations under the License.
  */
 
+
 description = 'mnemonic-examples'
-dependencies {
-  compileOnly project(':mnemonic-core')
-  compileOnly project(':mnemonic-collections')
-  compileOnly 'org.slf4j:slf4j-api'
-  compileOnly 'org.slf4j:jul-to-slf4j'
-  compileOnly 'org.slf4j:jcl-over-slf4j'
-  compileOnly 'log4j:log4j'
-  compileOnly 'org.slf4j:slf4j-log4j12'
+
+compileJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
 }
+
+compileTestJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
+}
+
+dependencies {
+  annotationProcessor project(':mnemonic-core')
+  api project(':mnemonic-collections')
+  api 'org.apache.commons:commons-lang3'
+  api 'org.flowcomputing.commons:commons-primitives'
+  api 'org.slf4j:slf4j-api'
+  api 'org.slf4j:jul-to-slf4j'
+  api 'org.slf4j:jcl-over-slf4j'
+  api 'log4j:log4j'
+  api 'org.slf4j:slf4j-log4j12'
+  testCompileOnly 'org.testng:testng'
+}
+
+test.useTestNG()


### PR DESCRIPTION
convert mnemonic-example build from maven to gradle as other subproject folders