### PR TITLE
MNEMONIC-566: Complete the Gradle build for mnemonic-utilities-service in mnemonic-computing-services

### DIFF
--- a/mnemonic-computing-services/mnemonic-utilities-service/build.gradle
+++ b/mnemonic-computing-services/mnemonic-utilities-service/build.gradle
@@ -15,8 +15,49 @@
  * limitations under the License.
  */
 
-description = 'mnemonic-utilities-service'
-dependencies {
-    testCompileOnly 'org.testng:testng'
+plugins {
+  id 'net.freudasoft.gradle-cmake-plugin'
+  id 'com.github.johnrengelman.shadow'
+  id 'com.google.osdetector'
 }
+
+description = 'mnemonic-utilities-service'
+
+dependencies {
+  implementation project(':mnemonic-core')
+  implementation project(':mnemonic-collections')
+  implementation 'org.flowcomputing.commons:commons-primitives'
+  testCompileOnly 'org.testng:testng'
+}
+
+def nativeDir = "$projectDir/src/main/native"
+
+cmake {
+  sourceFolder = file("$nativeDir")
+  workingFolder = file("$nativeDir/build")
+  buildSharedLibs = true
+  buildConfig = 'Release'
+  buildTarget = 'install'
+}
+
+task copyResources(type: Copy) {
+  from "$nativeDir/dist/native"
+  into "${buildDir}/classes/java/main/native"
+}
+
+shadowJar {
+  minimize()
+  destinationDirectory = file("$projectDir/../service-dist")
+  archiveClassifier = osdetector.classifier
+}
+
+task cleanDist(type: Delete) {
+  delete "$nativeDir/dist"
+}
+
+compileJava.dependsOn cmakeBuild
+processResources.dependsOn copyResources
+build.dependsOn shadowJar
+clean.dependsOn cmakeClean
+clean.dependsOn cleanDist
 test.useTestNG()


### PR DESCRIPTION
There is a computing service needs to get built with Gradle. Its structure is similar to mnemonic memory service so we can refer to their build.gradle files to complete this ticket.

Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning

BUILD SUCCESSFUL in 10s
15 actionable tasks: 8 executed, 7 up-to-date

Signed-off-by: Yanhui Zhao <yzhao@apache.org>