### PR TITLE
MNEMONIC-571: Create build.gradle for subproject mnemonic-spark

### DIFF
--- a/mnemonic-spark/mnemonic-spark-core/build.gradle
+++ b/mnemonic-spark/mnemonic-spark-core/build.gradle
@@ -15,8 +15,45 @@
  * limitations under the License.
  */
 
-description = 'mnemonic-spark-core'
-dependencies {
-    testCompileOnly 'org.testng:testng'
+plugins {
+    id 'scala'
 }
+
+description = 'mnemonic-spark-core'
+
+compileJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
+}
+
+compileTestJava {
+  options.compilerArgs = [
+    "-processor", "org.apache.mnemonic.DurableEntityProcessor"
+  ]
+}
+
+dependencies {
+  def spark_version = '2.3.0'
+  def scala_version = '2.11.12'
+  def scala_bin_version = '2.11'
+  def scalatest_version = '3.0.1'
+
+  annotationProcessor project(':mnemonic-core')
+  api project(':mnemonic-collections')
+  api project(':mnemonic-sessions')
+  api 'org.apache.commons:commons-lang3'
+  api 'org.flowcomputing.commons:commons-primitives'
+  implementation "org.apache.spark:spark-core_${scala_bin_version}:${spark_version}"
+  implementation "org.apache.spark:spark-mllib_${scala_bin_version}:${spark_version}"
+  implementation "org.scala-lang:scala-library:${scala_version}"
+  api 'org.slf4j:slf4j-api'
+  api 'org.slf4j:jul-to-slf4j'
+  api 'org.slf4j:jcl-over-slf4j'
+  api 'log4j:log4j'
+  api 'org.slf4j:slf4j-log4j12'
+  testCompileOnly 'org.testng:testng'
+  testImplementation "org.scalatest:scalatest_${scala_bin_version}:${scalatest_version}"
+}
+
 test.useTestNG()


### PR DESCRIPTION
$ ./gradlew :mnemonic-spark:mnemonic-spark-core:clean -x test
Starting a Gradle Daemon (subsequent builds will be faster)

BUILD SUCCESSFUL in 7s
1 actionable task: 1 up-to-date
$ ./gradlew :mnemonic-spark:mnemonic-spark-core:build -x test

> Task :mnemonic-sessions:compileJava
Note: /mnt/c/Users/Yanhui/mnemonic/mnemonic-sessions/src/main/java/org/apache/mnemonic/sessions/DurableInputSession.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

BUILD SUCCESSFUL in 2m 8s
8 actionable tasks: 4 executed, 4 up-to-date

Signed-off-by: Yanhui Zhao <yzhao@apache.org>