### PR TITLE
MNEMONIC-599: Replace the Utils.getVolatileMemoryAllocatorService call from Example

### DIFF
--- a/mnemonic-examples/build.gradle
+++ b/mnemonic-examples/build.gradle
@@ -33,6 +33,8 @@ compileTestJava {
 dependencies {
   annotationProcessor project(':mnemonic-core')
   api project(':mnemonic-collections')
+  api project(':mnemonic-memory-services:mnemonic-nvml-vmem-service')
+  api project(':mnemonic-memory-services:mnemonic-nvml-pmem-service')
   api 'org.apache.commons:commons-lang3'
   api 'org.flowcomputing.commons:commons-primitives'
   api 'org.slf4j:slf4j-api'

--- a/mnemonic-examples/pom.xml
+++ b/mnemonic-examples/pom.xml
@@ -55,6 +55,16 @@
       <artifactId>mnemonic-collections</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.mnemonic</groupId>
+      <artifactId>mnemonic-nvml-vmem-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.mnemonic</groupId>
+      <artifactId>mnemonic-nvml-pmem-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- logging dependencies -->
     <!-- assume all APIs will be used -->
     <dependency>

--- a/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/CreateOrder.java
+++ b/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/CreateOrder.java
@@ -21,9 +21,9 @@ import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.collections.DurableSinglyLinkedList;
 import org.apache.mnemonic.collections.DurableSinglyLinkedListFactory;
+import org.apache.mnemonic.service.memory.internal.PMemServiceImpl;
 
 import java.text.SimpleDateFormat;
 
@@ -32,7 +32,7 @@ public class CreateOrder {
   public static void main(String[] argv) throws Exception {
 
     /* create a non-volatile memory pool from one of memory services */
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMemServiceImpl(),
         1024L * 1024 * 1024, "./example_order.dat", true);
 
     System.out.printf("Creating Customer info...\n");

--- a/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/HelloWorld.java
+++ b/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/HelloWorld.java
@@ -22,13 +22,14 @@ import org.apache.mnemonic.NonVolatileMemAllocator;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.collections.DurableString;
 import org.apache.mnemonic.collections.DurableStringFactory;
+import org.apache.mnemonic.service.memory.internal.PMemServiceImpl;
 
 public class HelloWorld {
 
   public static void main(String[] argv) throws Exception {
 
     /* create a non-volatile memory pool from one of memory services */
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMemServiceImpl(),
         1024L * 1024 * 1024, "./example_helloworld.dat", true);
 
     /* create durable string object */

--- a/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/Main.java
+++ b/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/Main.java
@@ -28,6 +28,8 @@ import org.apache.mnemonic.MemClustering;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.SysMemAllocator;
 import org.apache.mnemonic.Utils;
+import org.apache.mnemonic.service.memory.internal.VMemServiceImpl;
+// import org.apache.mnemonic.service.memory.internal.PMemServiceImpl;
 
 import sun.misc.Unsafe;
 
@@ -65,8 +67,8 @@ public class Main {
         // true).disableActiveGC(),
         // MemClustering.PerformanceLevel.NORMAL),
         new MemClustering.NodeConfig(
-            new VolatileMemAllocator(Utils.getVolatileMemoryAllocatorService("vmem"), 1024 * 1024 * 20, "."),
-            // Utils.getVolatileMemoryAllocatorService("pmalloc"),
+            new VolatileMemAllocator(new VMemServiceImpl(), 1024 * 1024 * 20, "."),
+            // new PMemServiceImpl(),
             // 1024 * 1024 * 20, "./example.dat", true),
             MemClustering.PerformanceLevel.SLOW), };
 

--- a/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/ShowOrder.java
+++ b/mnemonic-examples/src/main/java/org/apache/mnemonic/examples/ShowOrder.java
@@ -21,14 +21,14 @@ import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.Utils;
+import org.apache.mnemonic.service.memory.internal.PMemServiceImpl;
 
 public class ShowOrder {
 
   public static void main(String[] argv) throws Exception {
 
     /* create a non-volatile memory pool from one of memory services */
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMemServiceImpl(),
         1024L * 1024 * 1024, "./example_order.dat", false);
 
     DurableType listgftypes[] = {DurableType.DURABLE};


### PR DESCRIPTION
Signed-off-by: Xiaojin Jiao <xj.jiao@gmail.com>