### PR TITLE
MNEMONIC-603: Replace the Utils.getNonVolatileMemoryAllocatorService from Collections

### DIFF
--- a/mnemonic-collections/build.gradle
+++ b/mnemonic-collections/build.gradle
@@ -33,6 +33,7 @@ compileTestJava {
 dependencies {
   annotationProcessor project(':mnemonic-core')
   api project(':mnemonic-core')
+  api project(':mnemonic-memory-services:mnemonic-pmalloc-service')
   api 'org.apache.commons:commons-lang3'
   api 'org.flowcomputing.commons:commons-primitives'
   api 'org.slf4j:slf4j-api'

--- a/mnemonic-collections/pom.xml
+++ b/mnemonic-collections/pom.xml
@@ -39,6 +39,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.mnemonic</groupId>
+      <artifactId>mnemonic-pmalloc-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.DurableBuffer;
 import org.apache.mnemonic.DurableChunk;
@@ -92,7 +93,7 @@ public class DurableArrayNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_array.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
@@ -26,6 +26,7 @@ import java.util.zip.CRC32;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.DurableType;
@@ -92,7 +93,7 @@ public class DurableHashMapNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_hashmaps.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashSetNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashSetNGTest.java
@@ -25,6 +25,7 @@ import java.util.zip.Checksum;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.DurableBuffer;
 import org.apache.mnemonic.DurableChunk;
@@ -92,7 +93,7 @@ public class DurableHashSetNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_hashset.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurablePersonNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurablePersonNGTest.java
@@ -22,6 +22,7 @@ import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.RetrieveDurableEntityError;
 import org.apache.mnemonic.Utils;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -38,7 +39,7 @@ public class DurablePersonNGTest {
   @Test(expectedExceptions = { OutOfHybridMemory.class })
   public void testGenPeople() throws OutOfHybridMemory, RetrieveDurableEntityError {
     Random rand = Utils.createRandom();
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMallocServiceImpl(),
         1024 * 1024 * 8, "./pobj_person.dat", true);
     cKEYCAPACITY = act.handlerCapacity();
     act.setBufferReclaimer(new Reclaim<ByteBuffer>() {
@@ -110,7 +111,7 @@ public class DurablePersonNGTest {
 
   @Test(dependsOnMethods = { "testGenPeople" })
   public void testCheckPeople() throws RetrieveDurableEntityError {
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMallocServiceImpl(),
         1024 * 1024 * 8, "./pobj_person.dat", true);
     act.setBufferReclaimer(new Reclaim<ByteBuffer>() {
       @Override

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Utils;
@@ -47,7 +48,7 @@ public class DurableSinglyLinkedListNGTest {
   @BeforeClass
   public void setUp() {
     m_rand = Utils.createRandom();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_NodeValue.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListWithParamHolderNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListWithParamHolderNGTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Utils;
@@ -49,7 +50,7 @@ public class DurableSinglyLinkedListWithParamHolderNGTest {
   @BeforeClass
   public void setUp() {
     m_rand = Utils.createRandom();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_NodeValue_WithParamHolder.dat", true);
     ph = new ParameterHolder();
 

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 //import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.DurableType;
@@ -52,7 +53,7 @@ public class DurableTreeNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
         "./pobj_tree.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {


### PR DESCRIPTION
Signed-off-by: Xiaojin Jiao <xj.jiao@gmail.com>