### PR TITLE
MNEMONIC-605: Replace the Utils.getVolatileMemoryAllocatorService from Benches

### DIFF
--- a/mnemonic-benches/mnemonic-sort-bench/build.gradle
+++ b/mnemonic-benches/mnemonic-sort-bench/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   annotationProcessor project(':mnemonic-core')
   api project(':mnemonic-collections')
   api project(':mnemonic-computing-services:mnemonic-utilities-service')
+  api project(':mnemonic-memory-services:mnemonic-sys-vmem-service')
   api 'commons-cli:commons-cli'
   api 'org.apache.commons:commons-lang3'
   api 'org.flowcomputing.commons:commons-primitives'

--- a/mnemonic-benches/mnemonic-sort-bench/src/main/java/org/apache/mnemonic/bench/DNCSTextFileSort.java
+++ b/mnemonic-benches/mnemonic-sort-bench/src/main/java/org/apache/mnemonic/bench/DNCSTextFileSort.java
@@ -21,6 +21,7 @@ import org.apache.mnemonic.DurableType;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.VolatileMemAllocator;
+import org.apache.mnemonic.service.memory.internal.SysVMemServiceImpl;
 import org.apache.mnemonic.collections.DurableSinglyLinkedList;
 import org.apache.mnemonic.collections.DurableSinglyLinkedListFactory;
 import org.apache.mnemonic.collections.SinglyLinkedNode;
@@ -52,7 +53,7 @@ public class DNCSTextFileSort implements TextFileSort {
     if (null != m_act) {
       clear();
     }
-    m_act = new VolatileMemAllocator(Utils.getVolatileMemoryAllocatorService("sysvmem"), 1024 * 1024 * 1024 * 5,
+    m_act = new VolatileMemAllocator(new SysVMemServiceImpl(), 1024 * 1024 * 1024 * 5,
         uri);
     String text = null;
     SinglyLinkedNode<Long> curnode = null, prvnode = null, node = null;

--- a/mnemonic-benches/pom.xml
+++ b/mnemonic-benches/pom.xml
@@ -51,6 +51,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.mnemonic</groupId>
+      <artifactId>mnemonic-sys-vmem-service</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.mnemonic</groupId>
       <artifactId>mnemonic-spark-core</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
Signed-off-by: Xiaojin Jiao <xj.jiao@gmail.com>