### PR TITLE
MNEMONIC-621: Add Utils.getNonVolatileMemoryAllocatorService call back to Collections

### DIFF
--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableArrayNGTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.DurableBuffer;
 import org.apache.mnemonic.DurableChunk;
@@ -93,7 +92,7 @@ public class DurableArrayNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_array.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashMapNGTest.java
@@ -26,7 +26,6 @@ import java.util.zip.CRC32;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.DurableType;
@@ -93,7 +92,7 @@ public class DurableHashMapNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_hashmaps.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashSetNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableHashSetNGTest.java
@@ -25,7 +25,6 @@ import java.util.zip.Checksum;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.DurableBuffer;
 import org.apache.mnemonic.DurableChunk;
@@ -93,7 +92,7 @@ public class DurableHashSetNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_hashset.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurablePersonNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurablePersonNGTest.java
@@ -22,7 +22,6 @@ import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.RetrieveDurableEntityError;
 import org.apache.mnemonic.Utils;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.testng.annotations.Test;
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -39,7 +38,7 @@ public class DurablePersonNGTest {
   @Test(expectedExceptions = { OutOfHybridMemory.class })
   public void testGenPeople() throws OutOfHybridMemory, RetrieveDurableEntityError {
     Random rand = Utils.createRandom();
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMallocServiceImpl(),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
         1024 * 1024 * 8, "./pobj_person.dat", true);
     cKEYCAPACITY = act.handlerCapacity();
     act.setBufferReclaimer(new Reclaim<ByteBuffer>() {
@@ -111,7 +110,7 @@ public class DurablePersonNGTest {
 
   @Test(dependsOnMethods = { "testGenPeople" })
   public void testCheckPeople() throws RetrieveDurableEntityError {
-    NonVolatileMemAllocator act = new NonVolatileMemAllocator(new PMallocServiceImpl(),
+    NonVolatileMemAllocator act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"),
         1024 * 1024 * 8, "./pobj_person.dat", true);
     act.setBufferReclaimer(new Reclaim<ByteBuffer>() {
       @Override

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListNGTest.java
@@ -25,7 +25,6 @@ import java.util.Random;
 
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Utils;
@@ -48,7 +47,7 @@ public class DurableSinglyLinkedListNGTest {
   @BeforeClass
   public void setUp() {
     m_rand = Utils.createRandom();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_NodeValue.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListWithParamHolderNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableSinglyLinkedListWithParamHolderNGTest.java
@@ -25,7 +25,6 @@ import java.util.Random;
 
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.Reclaim;
 import org.apache.mnemonic.Utils;
@@ -50,7 +49,7 @@ public class DurableSinglyLinkedListWithParamHolderNGTest {
   @BeforeClass
   public void setUp() {
     m_rand = Utils.createRandom();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_NodeValue_WithParamHolder.dat", true);
     ph = new ParameterHolder();
 

--- a/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
+++ b/mnemonic-collections/src/test/java/org/apache/mnemonic/collections/DurableTreeNGTest.java
@@ -24,7 +24,6 @@ import java.util.Random;
 import org.apache.mnemonic.EntityFactoryProxyHelper;
 import org.apache.mnemonic.Utils;
 import org.apache.mnemonic.NonVolatileMemAllocator;
-import org.apache.mnemonic.service.memory.internal.PMallocServiceImpl;
 //import org.apache.mnemonic.OutOfHybridMemory;
 import org.apache.mnemonic.EntityFactoryProxy;
 import org.apache.mnemonic.DurableType;
@@ -53,7 +52,7 @@ public class DurableTreeNGTest {
   public void setUp() throws Exception {
     rand = Utils.createRandom();
     unsafe = Utils.getUnsafe();
-    m_act = new NonVolatileMemAllocator(new PMallocServiceImpl(), 1024 * 1024 * 1024,
+    m_act = new NonVolatileMemAllocator(Utils.getNonVolatileMemoryAllocatorService("pmalloc"), 1024 * 1024 * 1024,
         "./pobj_tree.dat", true);
     cKEYCAPACITY = m_act.handlerCapacity();
     m_act.setBufferReclaimer(new Reclaim<ByteBuffer>() {


### PR DESCRIPTION
Signed-off-by: Xiaojin Jiao <xj.jiao@gmail.com>