### PR TITLE
MNEMONIC-657: Mnemonic release script should be updated to remove compiled code files in prepared release candidates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ project.gradle.startParameter.excludedTaskNames.add('test')
 
 allprojects  {
   group = 'org.apache.mnemonic'
-  version = '0.14.0-SNAPSHOT'
+  version = '0.15.0-SNAPSHOT'
 }
 
 subprojects {
@@ -55,8 +55,8 @@ subprojects {
     mavenCentral()
   }
 
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+  sourceCompatibility = 14
+  targetCompatibility = 14
   tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
   }

--- a/tools/source-assembly.xml
+++ b/tools/source-assembly.xml
@@ -277,10 +277,7 @@
         <include>pom.xml</include>
         <include>tools/**</include>
         <include>docker/**</include>
-        <include>gradle/**</include>
         <include>settings.gradle</include>
-        <include>gradlew</include>
-        <include>gradlew.bat</include>
         <include>build.gradle</include>
       </includes>
       <useDefaultExcludes>true</useDefaultExcludes>


### PR DESCRIPTION
source-assembly.xml has been updated to exclude gradle and gradlew
Version is also updated in build.gradle

Signed-off-by: Xiaojin Jiao <xjiao@apache.org>