### PR TITLE
MNEMONIC-665:Fix non-supported forkmode and java.ext.dirs in Spark test suites

### DIFF
--- a/mnemonic-spark/pom.xml
+++ b/mnemonic-spark/pom.xml
@@ -158,9 +158,8 @@
             <junitxml>.</junitxml>
             <parallel>false</parallel>
             <filereports>SparkIntegrationTestSuite.txt</filereports>
-            <forkMode>always</forkMode>
+            <forkMode>once</forkMode>
             <skipTests>${skipTests}</skipTests>
-            <argLine>-Djava.ext.dirs=${memory.service.dist.dir}:${computing.service.dist.dir}</argLine>
             <systemProperties>
               <spark.durable-basedir>
                 ./target


### PR DESCRIPTION
…st suites

Signed-off-by: Chunyong He <chunyong.he@gmail.com>