### PR TITLE
MNEMONIC-703: Add redis memory service in mnemonic project

### DIFF
--- a/mnemonic-memory-services/mnemonic-redis-service/build.gradle
+++ b/mnemonic-memory-services/mnemonic-redis-service/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+  id 'com.github.johnrengelman.shadow'
+  id 'com.google.osdetector'
+}
+
+description = 'mnemonic-redis-service'
+
+dependencies {
+  implementation project(':mnemonic-common')
+  testCompileOnly 'org.testng:testng'
+}
+
+shadowJar {
+  minimize()
+  destinationDirectory = file("$projectDir/../service-dist")
+  archiveClassifier = osdetector.classifier
+}
+
+build.dependsOn shadowJar
+
+test.useTestNG()

--- a/mnemonic-memory-services/mnemonic-redis-service/pom.xml
+++ b/mnemonic-memory-services/mnemonic-redis-service/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0"?>
+
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.mnemonic</groupId>
+    <artifactId>mnemonic-memory-services</artifactId>
+    <version>0.17.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mnemonic-redis-service</artifactId>
+  <name>mnemonic-redis-service</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <configuration>
+          <checkoutDirectory>${project.build.directory}/scmpublish</checkoutDirectory>
+          <checkinComment>Publishing javadoc for ${project.artifactId}:${project.version}</checkinComment>
+          <content>${project.reporting.outputDirectory}/apidocs</content>
+          <skipDeletedFiles>true</skipDeletedFiles>
+          <pubScmUrl>scm:git:https://github.com/bigdata-memory/mnenomic-project.git</pubScmUrl>
+          <scmBranch>gh-pages</scmBranch> <!-- branch with static site -->
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>doc</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <aggregate>true</aggregate>
+              <show>public</show>
+              <nohelp>true</nohelp>
+              <header></header>
+              <footer></footer>
+              <doctitle>Mnenomic, ${project.version}</doctitle>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>-Xmx2g -XX:MaxPermSize=1g</argLine>
+              <suiteXmlFiles>
+                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+              </suiteXmlFiles>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+
+</project>

--- a/mnemonic-memory-services/mnemonic-redis-service/src/main/java/org/apache/mnemonic/service/memory/internal/RedisServiceImpl.java
+++ b/mnemonic-memory-services/mnemonic-redis-service/src/main/java/org/apache/mnemonic/service/memory/internal/RedisServiceImpl.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mnemonic.service.memory.internal;
+
+import org.apache.mnemonic.query.memory.EntityInfo;
+import org.apache.mnemonic.query.memory.ResultSet;
+import org.apache.mnemonic.service.computing.ValueInfo;
+import org.apache.mnemonic.service.memory.MemoryServiceFeature;
+import org.apache.mnemonic.service.memory.NonVolatileMemoryAllocatorService;
+import org.apache.mnemonic.resgc.ReclaimContext;
+
+import java.nio.ByteBuffer;
+import java.util.Set;
+
+public class RedisServiceImpl implements NonVolatileMemoryAllocatorService {
+
+  @Override
+  public String getServiceId() {
+    return "redis";
+  }
+
+  @Override
+  public long init(long capacity, String uri, boolean isnew) {
+    return -1;
+  }
+
+  @Override
+  public long adjustCapacity(long id, long reserve) {
+    return -1;
+  }
+
+  @Override
+  public void close(long id) {
+  }
+
+  @Override
+  public void syncToVolatileMemory(long id, long addr, long length, boolean autodetect) {
+  }
+
+  @Override
+  public long capacity(long id) {
+    return -1;
+  }
+
+  @Override
+  public long allocate(long id, long size, boolean initzero) {
+    return -1;
+  }
+
+  @Override
+  public long reallocate(long id, long addr, long size, boolean initzero) {
+    return -1;
+  }
+
+  @Override
+  public void free(long id, long addr, ReclaimContext rctx) {
+  }
+
+  @Override
+  public ByteBuffer createByteBuffer(long id, long size) {
+    return null;
+  }
+
+  @Override
+  public ByteBuffer resizeByteBuffer(long id, ByteBuffer bytebuf, long size) {
+    return null;
+  }
+
+  @Override
+  public void destroyByteBuffer(long id, ByteBuffer bytebuf, ReclaimContext rctx) {
+  }
+
+  @Override
+  public ByteBuffer retrieveByteBuffer(long id, long handler) {
+    return null;
+  }
+
+  @Override
+  public long retrieveSize(long id, long handler) {
+    return -1;
+  }
+
+  @Override
+  public long getByteBufferHandler(long id, ByteBuffer buf) {
+    return -1;
+  }
+
+  @Override
+  public void setHandler(long id, long key, long handler) {
+  }
+
+  @Override
+  public long getHandler(long id, long key) {
+    return -1;
+  }
+
+  @Override
+  public long handlerCapacity(long id) {
+    return -1;
+  }
+
+  @Override
+  public void syncToNonVolatileMemory(long id, long addr, long length, boolean autodetect) {
+  }
+
+  @Override
+  public void syncToLocal(long id, long addr, long length, boolean autodetect) {
+  }
+
+  @Override
+  public void drain(long id) {
+  }
+
+  @Override
+  public long getBaseAddress(long id) {
+    return -1;
+  }
+
+  @Override
+  public void beginTransaction(boolean readOnly) {
+  }
+
+  @Override
+  public void commitTransaction() {
+  }
+
+  @Override
+  public void abortTransaction() {
+  }
+
+  @Override
+  public boolean isInTransaction() {
+    return false;
+  }
+
+  @Override
+  public Set<MemoryServiceFeature> getFeatures() {
+    return null;
+  }
+
+  @Override
+  public byte[] getAbstractAddress(long addr) {
+    return null;
+  }
+
+  @Override
+  public long getPortableAddress(long addr) {
+    return -1;
+  }
+
+  @Override
+  public long getEffectiveAddress(long addr) {
+    return -1;
+  }
+
+  @Override
+  public long[] getMemoryFunctions() {
+    return null;
+  }
+
+  /* Optional Queryable Service */
+
+  @Override
+  public String[] getClassNames(long id) {
+    return null;
+  }
+
+  @Override
+  public String[] getEntityNames(long id, String clsname) {
+    return null;
+  }
+
+  @Override
+  public EntityInfo getEntityInfo(long id, String clsname, String etyname) {
+    return null;
+  }
+
+  @Override
+  public void createEntity(long id, EntityInfo entityinfo) {
+  }
+
+  @Override
+  public void destroyEntity(long id, String clsname, String etyname) {
+  }
+
+  @Override
+  public void updateQueryableInfo(long id, String clsname, String etyname, ValueInfo updobjs) {
+  }
+
+  @Override
+  public void deleteQueryableInfo(long id, String clsname, String etyname, ValueInfo updobjs) {
+  }
+
+  @Override
+  public ResultSet query(long id, String querystr) {
+    return null;
+  }
+
+}

--- a/mnemonic-memory-services/mnemonic-redis-service/src/main/resources/META-INF/services/org.apache.mnemonic.service.memory.NonVolatileMemoryAllocatorService
+++ b/mnemonic-memory-services/mnemonic-redis-service/src/main/resources/META-INF/services/org.apache.mnemonic.service.memory.NonVolatileMemoryAllocatorService
@@ -1,0 +1,1 @@
+org.apache.mnemonic.service.memory.internal.RedisServiceImpl

--- a/mnemonic-memory-services/mnemonic-redis-service/src/main/resources/log4j.properties
+++ b/mnemonic-memory-services/mnemonic-redis-service/src/main/resources/log4j.properties
@@ -1,0 +1,33 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Root logger option
+log4j.rootLogger=INFO, file, stdout
+
+#to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+#to log.log file
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=log.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n

--- a/mnemonic-memory-services/pom.xml
+++ b/mnemonic-memory-services/pom.xml
@@ -39,6 +39,7 @@
   </properties>
 
   <modules>
+    <module>mnemonic-redis-service</module>
     <module>mnemonic-nvml-vmem-service</module>
     <module>mnemonic-nvml-pmem-service</module>
     <module>mnemonic-pmalloc-service</module>


### PR DESCRIPTION
For redis integration into mnemonic as backend storage, we need to add the redis memory service to the project