### PR TITLE
MNEMONIC-725:Keep thread information when get InterruptedException

### DIFF
--- a/mnemonic-core/src/main/java/org/apache/mnemonic/Utils.java
+++ b/mnemonic-core/src/main/java/org/apache/mnemonic/Utils.java
@@ -214,7 +214,7 @@ public class Utils {
       System.runFinalization();
       Thread.sleep(timeout);
     } catch (InterruptedException ex) {
-      ex.printStackTrace();
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
Keep thread information when get InterruptedException
Signed-off-by: chenyang <chenyang@apache.org>