### PR TITLE
MNEMONIC-726: Adding initial version of VSCode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ GPATH
 GRTAGS
 GTAGS
 TAGS
+.dccache

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 {
     "atlascode.enableCurlLogging": false,
     "atlascode.jira.showCreateIssueProblems": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "atlascode.enableCurlLogging": false,
+    "atlascode.jira.showCreateIssueProblems": false,
+    "atlascode.enableCharles": false,
+    "atlascode.bitbucket.enabled": false
+}


### PR DESCRIPTION
This PR adds initial settings folder and ignore dccode file accordingly. 