### PR TITLE
MNEMONIC-732: Exclude dccache from license check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
               <exclude>gradlew/</exclude>
               <exclude>gradlew.bat</exclude>
               <exclude>**/build/</exclude>
+              <exclude>.dccache</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
This PR excludes .dccache file from license checklist.