### PR TITLE
MNEMONIC-733: identified 5 more critical security vulnerabilities

### DIFF
--- a/mnemonic-benches/pom.xml
+++ b/mnemonic-benches/pom.xml
@@ -40,7 +40,7 @@
 
   <modules>
     <module>mnemonic-sort-bench</module>
-    <module>mnemonic-spark-kmeans-bench</module>
+    <!-- <module>mnemonic-spark-kmeans-bench</module> -->
   </modules>
 
   <dependencies>
@@ -54,11 +54,11 @@
       <artifactId>mnemonic-sys-vmem-service</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.mnemonic</groupId>
-      <artifactId>mnemonic-spark-core</artifactId>
-      <version>${project.version}</version>
-    </dependency>
+    <!-- <dependency> -->
+    <!--   <groupId>org.apache.mnemonic</groupId> -->
+    <!--   <artifactId>mnemonic-spark-core</artifactId> -->
+    <!--   <version>${project.version}</version> -->
+    <!-- </dependency> -->
     <dependency>
       <groupId>org.apache.mnemonic</groupId>
       <artifactId>mnemonic-collections</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <module>mnemonic-common</module>
     <module>mnemonic-sessions</module>
     <module>mnemonic-hadoop</module>
-    <module>mnemonic-spark</module>
+    <!-- <module>mnemonic-spark</module> -->
     <module>mnemonic-benches</module>
   </modules>
 
@@ -339,6 +339,8 @@
               <exclude>gradlew.bat</exclude>
               <exclude>**/build/</exclude>
               <exclude>.dccache</exclude>
+              <exclude>mnemonic-spark/</exclude>
+              <exclude>**/mnemonic-spark-kmeans-bench/</exclude>
             </excludes>
           </configuration>
           <executions>
@@ -578,7 +580,7 @@
       <module>mnemonic-benches</module>
       <module>mnemonic-sessions</module>
       <module>mnemonic-hadoop</module>
-      <module>mnemonic-spark</module>
+      <!-- <module>mnemonic-spark</module> -->
     </modules>
   </profile>
 </profiles>

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,9 +31,9 @@ include ':mnemonic-computing-services:mnemonic-utilities-service'
 include ':mnemonic-computing-services'
 include ':mnemonic-common'
 include ':mnemonic-benches:mnemonic-sort-bench'
-include ':mnemonic-benches:mnemonic-spark-kmeans-bench'
+// include ':mnemonic-benches:mnemonic-spark-kmeans-bench'
 include ':mnemonic-sessions'
-include ':mnemonic-spark:mnemonic-spark-core'
+// include ':mnemonic-spark:mnemonic-spark-core'
 include ':mnemonic-hadoop:mnemonic-hadoop-mapreduce'
 
 project(':mnemonic-core').projectDir = "$rootDir/mnemonic-core" as File
@@ -51,7 +51,7 @@ project(':mnemonic-computing-services:mnemonic-utilities-service').projectDir = 
 project(':mnemonic-computing-services').projectDir = "$rootDir/mnemonic-computing-services" as File
 project(':mnemonic-common').projectDir = "$rootDir/mnemonic-common" as File
 project(':mnemonic-benches:mnemonic-sort-bench').projectDir = "mnemonic-benches/mnemonic-sort-bench" as File
-project(':mnemonic-benches:mnemonic-spark-kmeans-bench').projectDir = "$rootDir/mnemonic-benches/mnemonic-spark-kmeans-bench" as File
+// project(':mnemonic-benches:mnemonic-spark-kmeans-bench').projectDir = "$rootDir/mnemonic-benches/mnemonic-spark-kmeans-bench" as File
 project(':mnemonic-sessions').projectDir = "$rootDir/mnemonic-sessions" as File
-project(':mnemonic-spark:mnemonic-spark-core').projectDir = "$rootDir/mnemonic-spark/mnemonic-spark-core" as File
+// project(':mnemonic-spark:mnemonic-spark-core').projectDir = "$rootDir/mnemonic-spark/mnemonic-spark-core" as File
 project(':mnemonic-hadoop:mnemonic-hadoop-mapreduce').projectDir = "$rootDir/mnemonic-hadoop/mnemonic-hadoop-mapreduce" as File

--- a/tools/source-assembly.xml
+++ b/tools/source-assembly.xml
@@ -166,7 +166,7 @@
     <moduleSet>
       <includes>
         <include>org.apache.mnemonic:mnemonic-sort-bench</include>
-        <include>org.apache.mnemonic:mnemonic-spark-kmeans-bench</include>
+        <!-- <include>org.apache.mnemonic:mnemonic-spark-kmeans-bench</include> -->
       </includes>
       <sources>
         <fileSets>
@@ -223,47 +223,47 @@
         <outputDirectoryMapping>mnemonic-hadoop/${module.artifactId}</outputDirectoryMapping>
       </sources>
     </moduleSet>
-    <moduleSet>
-      <includes>
-        <include>org.apache.mnemonic:mnemonic-spark</include>
-      </includes>
-      <sources>
-        <fileSets>
-          <fileSet>
-            <directory>.</directory>
-            <outputDirectory>.</outputDirectory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <excludes>
-              <exclude>**/target/**</exclude>
-              <exclude>dependency-reduced-pom.xml</exclude>
-              <exclude>**/*.dat</exclude>
-              <exclude>**/*.mne</exclude>
-            </excludes>
-          </fileSet>
-        </fileSets>
-      </sources>
-    </moduleSet>
-    <moduleSet>
-      <includes>
-        <include>org.apache.mnemonic:mnemonic-spark-core</include>
-      </includes>
-      <sources>
-        <fileSets>
-          <fileSet>
-            <directory>.</directory>
-            <outputDirectory>.</outputDirectory>
-            <useDefaultExcludes>true</useDefaultExcludes>
-            <excludes>
-              <exclude>**/target/**</exclude>
-              <exclude>dependency-reduced-pom.xml</exclude>
-              <exclude>**/*.dat</exclude>
-              <exclude>**/*.mne</exclude>
-            </excludes>
-          </fileSet>
-        </fileSets>
-        <outputDirectoryMapping>mnemonic-spark/${module.artifactId}</outputDirectoryMapping>
-      </sources>
-    </moduleSet>
+    <!-- <moduleSet> -->
+    <!--   <includes> -->
+    <!--     <include>org.apache.mnemonic:mnemonic-spark</include> -->
+    <!--   </includes> -->
+    <!--   <sources> -->
+    <!--     <fileSets> -->
+    <!--       <fileSet> -->
+    <!--         <directory>.</directory> -->
+    <!--         <outputDirectory>.</outputDirectory> -->
+    <!--         <useDefaultExcludes>true</useDefaultExcludes> -->
+    <!--         <excludes> -->
+    <!--           <exclude>**/target/**</exclude> -->
+    <!--           <exclude>dependency-reduced-pom.xml</exclude> -->
+    <!--           <exclude>**/*.dat</exclude> -->
+    <!--           <exclude>**/*.mne</exclude> -->
+    <!--         </excludes> -->
+    <!--       </fileSet> -->
+    <!--     </fileSets> -->
+    <!--   </sources> -->
+    <!-- </moduleSet> -->
+    <!-- <moduleSet> -->
+    <!--   <includes> -->
+    <!--     <include>org.apache.mnemonic:mnemonic-spark-core</include> -->
+    <!--   </includes> -->
+    <!--   <sources> -->
+    <!--     <fileSets> -->
+    <!--       <fileSet> -->
+    <!--         <directory>.</directory> -->
+    <!--         <outputDirectory>.</outputDirectory> -->
+    <!--         <useDefaultExcludes>true</useDefaultExcludes> -->
+    <!--         <excludes> -->
+    <!--           <exclude>**/target/**</exclude> -->
+    <!--           <exclude>dependency-reduced-pom.xml</exclude> -->
+    <!--           <exclude>**/*.dat</exclude> -->
+    <!--           <exclude>**/*.mne</exclude> -->
+    <!--         </excludes> -->
+    <!--       </fileSet> -->
+    <!--     </fileSets> -->
+    <!--     <outputDirectoryMapping>mnemonic-spark/${module.artifactId}</outputDirectoryMapping> -->
+    <!--   </sources> -->
+    <!-- </moduleSet> -->
   </moduleSets>
   <fileSets>
     <fileSet>

--- a/tools/test.conf
+++ b/tools/test.conf
@@ -75,15 +75,15 @@ mvn -Dtest=MneMapreduceChunkDataTest test -pl mnemonic-hadoop/mnemonic-hadoop-ma
 mvn -Dtest=MneMapredBufferDataTest test -pl mnemonic-hadoop/mnemonic-hadoop-mapreduce -DskipTests=false
 
 # a testcase for module "mnemonic-spark/mnemonic-spark-core" that requires 'pmalloc' memory service to pass
-mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDLongDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
+# mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDLongDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
 
-mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDChunkDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
+# mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDChunkDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
 
-mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDPersonDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
+# mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDPersonDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
 
-mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDBufferDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
+# mvn -Dsuites=org.apache.mnemonic.spark.rdd.DurableRDDBufferDataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
 
-mvn -Dsuites=org.apache.mnemonic.spark.DurableBufferIODataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
+# mvn -Dsuites=org.apache.mnemonic.spark.DurableBufferIODataSpec test -pl mnemonic-spark/mnemonic-spark-core -DskipTests=false
 
 # a testcase for module "mnemonic-memory-services"
 mvn -Dtest=JavaVMemServiceImplNGTest test -pl mnemonic-memory-services/mnemonic-java-vmem-service -DskipTests=false


### PR DESCRIPTION
The whole spark module is excluded temporarily from our build system.
I had to add spark into exclude list of Apache Ant, otherwise it reported license error on those excluded directory.
