### PR TITLE
MNEMONIC-744: CMake Deprecation Warning

### DIFF
--- a/mnemonic-computing-services/mnemonic-utilities-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-computing-services/mnemonic-utilities-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(utilitiescomputing)
 
 configure_file (

--- a/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-nvml-pmem-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(pmemallocator)
 
 configure_file (

--- a/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-nvml-vmem-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(vmemallocator)
 
 configure_file (

--- a/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmalloc-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(pmallocallocator)
 
 include_directories(/usr/local/include)

--- a/mnemonic-memory-services/mnemonic-pmdk-pmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmdk-pmem-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(pmdkpmemallocator)
 
 configure_file (

--- a/mnemonic-memory-services/mnemonic-pmdk-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-pmdk-vmem-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(pmdkvmemallocator)
 
 configure_file (

--- a/mnemonic-memory-services/mnemonic-redis-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-redis-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(redisallocator)
 
 include_directories(/usr/local/include)

--- a/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/native/CMakeLists.txt
+++ b/mnemonic-memory-services/mnemonic-sys-vmem-service/src/main/native/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 project(sysvmemallocator)
 
 configure_file (


### PR DESCRIPTION
Increase the minimum version requirement of CMake from 2.8.11 to 3.12 to suppress the `Compatibility with CMake < 2.8.12` warning on Ubuntu 22.04.